### PR TITLE
Ensure mutex is unlocked in client.Stop

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -811,11 +811,12 @@ func (c *client) Close() {
 		Timestamp: time.Now().Unix(),
 	})
 
-	if c.mu.Lock(); c.conn != nil {
+	c.mu.Lock()
+	if c.conn != nil {
 		_ = c.conn.Close()
 		c.conn = nil
-		c.mu.Unlock()
 	}
+	c.mu.Unlock()
 
 	if b == nil {
 		return


### PR DESCRIPTION
## Problem

After running the broker for a while, clients will eventually time out publishing to it. Once this starts, no messages can be published.

Inspecting pprof when this happens shows many goroutines stuck waiting to submit to a queue implemented with a channel:
```
741 @ 0x403bd36 0x4007825 0x40073dd 0x499bf77 0x499be6b 0x49a1ae6 0x499e892 0x49abcb9 0x483c77d 0x483f205 0x42b4a09 0x42b667b 0x42b1d28 0x406dbc1
#	0x499bf76	github.com/fhmq/hmq/pool.(*WorkerPool).Submit+0x176		/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/pool/fixpool.go:34
#	0x499be6a	github.com/fhmq/hmq/broker.(*Broker).SubmitWork+0x6a		/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/broker/broker.go:139
#	0x49a1ae5	github.com/fhmq/hmq/broker.(*client).readLoop+0x465		/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/broker/client.go:180
#	0x499e891	github.com/fhmq/hmq/broker.(*Broker).handleConnection+0xbb1	/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/broker/broker.go:428
#	0x49abcb8	github.com/fhmq/hmq/broker.(*Broker).wsHandler+0x38		/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/broker/broker.go:206
#	0x483c77c	golang.org/x/net/websocket.Server.serveWebSocket+0x13c		/Users/travis/go/pkg/mod/golang.org/x/net@v0.0.0-20220617184016-355a448f1bc9/websocket/server.go:89
#	0x483f204	golang.org/x/net/websocket.Server.ServeHTTP+0xa4		/Users/travis/go/pkg/mod/golang.org/x/net@v0.0.0-20220617184016-355a448f1bc9/websocket/server.go:70
```

The goroutine responsible for receiving from that channel is stuck waiting to acquire a lock:
```
1 @ 0x403bd36 0x404cb4c 0x404cb26 0x4069725 0x4077ec5 0x49a774a 0x49a7736 0x49a2a05 0x499bffd 0x48399e4 0x406dbc1
#	0x4069724	sync.runtime_SemacquireMutex+0x24				/nix/store/in3jb5v3yfq753s94hlsl5ac7bq45i27-go-1.17.10/share/go/src/runtime/sema.go:71
#	0x4077ec4	sync.(*Mutex).lockSlow+0x164					/nix/store/in3jb5v3yfq753s94hlsl5ac7bq45i27-go-1.17.10/share/go/src/sync/mutex.go:138
#	0x49a7749	sync.(*Mutex).Lock+0x189					/nix/store/in3jb5v3yfq753s94hlsl5ac7bq45i27-go-1.17.10/share/go/src/sync/mutex.go:81
#	0x49a7735	github.com/fhmq/hmq/broker.(*client).Close+0x175		/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/broker/client.go:814
#	0x49a2a04	github.com/fhmq/hmq/broker.ProcessMessage+0x984			/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/broker/client.go:351
#	0x499bffc	github.com/fhmq/hmq/broker.(*Broker).SubmitWork.func1+0x1c	/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/broker/broker.go:140
#	0x48399e3	github.com/fhmq/hmq/pool.startWorker.func1+0x23			/Users/travis/go/pkg/mod/github.com/goforward/hmq@v0.0.0-20220722212626-6abd42cd86f4/pool/fixpool.go:55
```

In one of two places that this lock is taken, there is a branch that will fail to unlock.

The proposed fix is to unlock in both branches.